### PR TITLE
Fix build-time a11y warnings

### DIFF
--- a/interface/src/lib/components/InputPassword.svelte
+++ b/interface/src/lib/components/InputPassword.svelte
@@ -16,9 +16,12 @@
 <div class="relative">
 	<input {type} class="input w-full" {value} oninput={handleInput} {id} />
 	<div class="absolute inset-y-0 right-0 flex items-center pr-1">
-		<!-- svelte-ignore a11y_click_events_have_key_events -->
-		<svg
-			xmlns="http://www.w3.org/2000/svg"
+               <!-- svelte-ignore a11y_click_events_have_key_events -->
+               <svg
+                       role="button"
+                       aria-label="Hide password"
+                       tabindex="0"
+                       xmlns="http://www.w3.org/2000/svg"
 			class="text-base-content/50 h-6 {show ? 'block' : 'hidden'}"
 			onclick={() => (show = false)}
 			width="40"
@@ -38,9 +41,12 @@
 			<path d="M3 3l18 18" />
 		</svg>
 
-		<!-- svelte-ignore a11y_click_events_have_key_events -->
-		<svg
-			xmlns="http://www.w3.org/2000/svg"
+               <!-- svelte-ignore a11y_click_events_have_key_events -->
+               <svg
+                       role="button"
+                       aria-label="Show password"
+                       tabindex="0"
+                       xmlns="http://www.w3.org/2000/svg"
 			class="text-base-content/50 h-6 {show ? 'hidden' : 'block'}"
 			onclick={() => (show = true)}
 			width="40"

--- a/interface/src/lib/components/UpdateIndicator.svelte
+++ b/interface/src/lib/components/UpdateIndicator.svelte
@@ -17,8 +17,8 @@
 
 	let { update = $bindable(false) }: Props = $props();
 
-	let firmwareVersion: string;
-	let firmwareDownloadLink: string;
+       let firmwareVersion: string = $state('');
+       let firmwareDownloadLink: string = $state('');
 
 	async function getGithubAPI() {
 		const githubUrl = `https://api.github.com/repos/${page.data.github}/releases/latest`;

--- a/interface/src/routes/+layout.svelte
+++ b/interface/src/routes/+layout.svelte
@@ -161,14 +161,17 @@
 {/if}
 
 <Modals>
-	<!-- svelte-ignore a11y_click_events_have_key_events -->
-	{#snippet backdrop({ close })}
-		<div
-			class="fixed inset-0 z-40 max-h-full max-w-full bg-black/20 backdrop-blur-sm"
-			transition:fade|global
-			onclick={() => close()}
-		></div>
-	{/snippet}
+       <!-- svelte-ignore a11y_click_events_have_key_events -->
+       {#snippet backdrop({ close })}
+               <div
+                       role="button"
+                       aria-label="Close modal"
+                       tabindex="0"
+                       class="fixed inset-0 z-40 max-h-full max-w-full bg-black/20 backdrop-blur-sm"
+                       transition:fade|global
+                       onclick={() => close()}
+               ></div>
+       {/snippet}
 </Modals>
 
 <Toast />

--- a/interface/src/routes/wifi/sta/Scan.svelte
+++ b/interface/src/routes/wifi/sta/Scan.svelte
@@ -111,12 +111,15 @@
 					<ul class="menu w-full">
 						{#each listOfNetworks as network, i}
 							<li>
-								<!-- svelte-ignore a11y_click_events_have_key_events -->
-								<div
-									class="bg-base-200 rounded-btn my-1 flex items-center space-x-3 hover:scale-[1.02] active:scale-[0.98]"
-									onclick={() => {
-										storeNetwork(network.ssid);
-									}}
+                                                       <!-- svelte-ignore a11y_click_events_have_key_events -->
+                                                       <div
+                                                               role="button"
+                                                               aria-label="Select network"
+                                                               tabindex="0"
+                                                               class="bg-base-200 rounded-btn my-1 flex items-center space-x-3 hover:scale-[1.02] active:scale-[0.98]"
+                                                               onclick={() => {
+                                                                       storeNetwork(network.ssid);
+                                                               }}
 								>
 									<div class="mask mask-hexagon bg-primary h-auto w-10 shrink-0">
 										<Network class="text-primary-content h-auto w-full scale-75" />


### PR DESCRIPTION
## Summary
- fix various Svelte accessibility warnings
- make `firmwareVersion` and `firmwareDownloadLink` reactive

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688574f5c2348331b4ec554e5b845798